### PR TITLE
Update paths for production docker compose to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,14 +102,14 @@ Once the one-time installation step above is complete, the StarFall software can
 To start the application stack, run the following in a WSL terminal:
 
 ```bash
-cd StarFall/docker
-docker compose -f docker-compose.production.yml up
+cd StarFall
+docker compose -f ./docker/docker-compose.production.yml up
 ```
 
 A "-d" flag can be provided to run the Docker Compose command in a detached terminal:
 
 ```bash
-docker compose -f docker-compose.production.yml up -d
+docker compose -f ./docker/docker-compose.production.yml up -d
 ```
 
 You can verify that all services are running with:
@@ -127,7 +127,7 @@ docker compose logs -f
 To shut down the system and all containers, run the following command:
 
 ```bash
-docker compose -f docker-compose.production.yml down
+docker compose -f ./docker/docker-compose.production.yml down
 ```
 
 Additional details on how to run Docker compose commands can be found on [Docker’s online documentation](https://docs.docker.com/compose/).

--- a/docker/docker-compose.production.yml
+++ b/docker/docker-compose.production.yml
@@ -27,9 +27,9 @@ services:
         condition: service_healthy
     # environment:
     #   - DB_PASSWORD=password
-    # volumes:
+    volumes:
       ### ALTERNATIVE WAY TO OVERWRITE DEFAULT PRODUCTION CONFIG FILE ###
-      # - ./starfall-viewer-server-production.config:/etc/starfall/starfall-viewer-server-production.config 
+      - ../starfall-server/src/config/starfall-viewer-server-production.config:/etc/starfall/starfall-viewer-server-production.config 
       ### CREATE A `logs` DIRECTORY OR POINT TO LOGS DIRECTORY ###
       # - <LOG_DIR>:/opt/starfall/log/starfall-viewer/
       ### POINT THIS TO YOUR CERTS DIRECTORY ###

--- a/starfall-server/src/config/starfall-viewer-server-production.config
+++ b/starfall-server/src/config/starfall-viewer-server-production.config
@@ -49,8 +49,8 @@ appPort       8080
 # Certificates
 # SSL Certificates allow the server to serve StarFall Viewer using HTTPS
 # If commented out StarFall will serve over http
-sslCert       /etc/starfall/certs/cert.pem
-sslKey        /etc/starfall/certs/key.pem
+# sslCert       /etc/starfall/certs/cert.pem
+# sslKey        /etc/starfall/certs/key.pem
 
 # not using this value
 # subConnection tcp://GLMContainer:1236


### PR DESCRIPTION
Several of the paths for running docker compose production were broken.